### PR TITLE
Enabled dark and light mode with switch for docs using docsify-darklight-theme

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,5 +1,38 @@
 # Customization
 
+## Theme Switcher
+
+To switch between themes [theme](themes):
+
+Add styles same as below in your `index.html`
+
+```html
+<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@3/dist/docsify-themeable/style.min.css" type="text/css">
+```
+
+You can give any external or custom stylesheets from local based on you preference inside `href` on below two stylesheet links.
+
+Just [view the source of other themes](https://github.com/jhildenbiddle/docsify-themeable/tree/master/src/scss/themes), find the theme properties you like, and copy them to your custom stylesheet.
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css" title="light">
+<link rel="stylesheet alternative" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css" title="dark"> 
+```
+
+And finally add below two scripts on bottom of the `index.html`
+
+```html
+<script
+    src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@3/dist/docsify-themeable/main.min.js"
+    type="text/javascript">
+</script>
+
+<script
+    src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@3/dist/docsify-themeable/index.min.js"
+    type="text/javascript">
+</script>
+```
+
 ## Theme Styles
 
 To customize a *docsify-themeable* [theme](themes):

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,12 +10,13 @@
     <title>docsify-themeable - A delightfully simple theme system for docsify.js</title>
 
     <!-- Stylesheets -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css" title="Simple">
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@3/dist/docsify-themeable/style.min.css" type="text/css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css" title="light">
     <link rel="stylesheet" href="assets/css/main.css">
-
+    
     <!-- Alternate Stylesheets -->
+    <link rel="stylesheet alternative" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css" title="dark">
     <link rel="stylesheet alternate" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-defaults.css" title="Defaults">
-    <link rel="stylesheet alternate" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css" title="Simple Dark">
 
     <!-- Test Stylesheets -->
     <!-- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify@4/themes/vue.css"> -->
@@ -59,7 +60,8 @@
             }
         };
     </script>
-    <script src="assets/js/main.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@3/dist/docsify-themeable/main.min.js" type="text/javascript"></script>
+    <script src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@3/dist/docsify-themeable/index.min.js" type="text/javascript"></script>
     <script src="https://cdn.jsdelivr.net/npm/docsify@4"></script>
     <script src="https://cdn.jsdelivr.net/npm/docsify-themeable@0"></script>
     <script src="https://cdn.jsdelivr.net/npm/docsify-tabs@1"></script>


### PR DESCRIPTION
Hi @jhildenbiddle,

I add dark and light mode with switch for docs using [docsify-darklight-theme](https://docsify-darklight-theme.boopathikumar.me). As of now I used the default stylesheets provided by docsify-themeable and switch between them.

### Light Mode

![image](https://user-images.githubusercontent.com/10001746/82764438-4ca73e80-9e2c-11ea-8fd3-461dce582edb.png)

### Dark Mode

![image](https://user-images.githubusercontent.com/10001746/82764449-634d9580-9e2c-11ea-995f-f89db794158f.png)