### PR TITLE
Make `::selection` more visible in dark mode

### DIFF
--- a/src/scss/app/_base.scss
+++ b/src/scss/app/_base.scss
@@ -133,6 +133,7 @@ body:not([data-platform^="Mac"]) {
 
 ::selection {
     background: var(--selection-color);
+    color: var(--base-background-color);
 }
 
 // Classes

--- a/src/scss/app/_code.scss
+++ b/src/scss/app/_code.scss
@@ -55,6 +55,7 @@ pre[data-lang] ::-moz-selection,
 code[class*="lang-"]::-moz-selection,
 code[class*="lang-"] ::-moz-selection {
     background: var(--code-theme-selection, var(--selection-color));
+    color: var(--base-background-color);
 }
 
 pre[data-lang]::selection,
@@ -62,6 +63,7 @@ pre[data-lang] ::selection,
 code[class*="lang-"]::selection,
 code[class*="lang-"] ::selection {
     background: var(--code-theme-selection, var(--selection-color));
+    color: var(--base-background-color);
 }
 
 :not(pre) > code[class*="lang-"],

--- a/src/scss/app/_code.scss
+++ b/src/scss/app/_code.scss
@@ -55,7 +55,7 @@ pre[data-lang] ::-moz-selection,
 code[class*="lang-"]::-moz-selection,
 code[class*="lang-"] ::-moz-selection {
     background: var(--code-theme-selection, var(--selection-color));
-    color: var(--base-background-color);
+    color: inherit;
 }
 
 pre[data-lang]::selection,
@@ -63,7 +63,7 @@ pre[data-lang] ::selection,
 code[class*="lang-"]::selection,
 code[class*="lang-"] ::selection {
     background: var(--code-theme-selection, var(--selection-color));
-    color: var(--base-background-color);
+    color: inherit;
 }
 
 :not(pre) > code[class*="lang-"],


### PR DESCRIPTION
### Before: 
Demo - basic one, only enabled dark theme
https://codesandbox.io/s/demo-docsify-themeable-forked-dd3g8?file=/index.html

![image](https://user-images.githubusercontent.com/1719476/92937944-40330a00-f44c-11ea-8035-15d6ede6d33e.png)
![image](https://user-images.githubusercontent.com/1719476/92938050-6193f600-f44c-11ea-8458-62e89bdbbadd.png)

### After:
Demo - added custom `<style>` in `index.html`
https://codesandbox.io/s/demo-docsify-themeable-forked-wyfyr

![image](https://user-images.githubusercontent.com/1719476/92937999-52ad4380-f44c-11ea-8e42-29f337ee761e.png)
![image](https://user-images.githubusercontent.com/1719476/92938100-6eb0e500-f44c-11ea-8795-09482ab89c81.png)

White mode:
![image](https://user-images.githubusercontent.com/1719476/93100539-8df87e00-f6a9-11ea-8853-961cefa57e7d.png)

